### PR TITLE
added gen3 Mii data file formats

### DIFF
--- a/game/MiiStudio_Miidatafile.ksy
+++ b/game/MiiStudio_Miidatafile.ksy
@@ -1,0 +1,142 @@
+meta:
+  id: miidata_ms
+  endian: le
+seq:
+  - id: facial_hair_color
+    type: u1
+    doc: Facial hair color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: beard_goatee
+    type: u1
+    doc: Beard (goatee) type. Ranges from 0 to 5.
+  - id: body_weight
+    type: u1
+    doc: Body weight. Ranges from 0 to 127, small to large.
+  - id: eye_stretch
+    type: u1
+    doc: Eye stretch. Ranges from 0 to 6, small to large.
+  - id: eye_color
+    type: u1
+    doc: Eye color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: eye_rotation
+    type: u1
+    doc: Eye rotation. Ranges from 0 to 7, down to up. Note that some eye types have a default rotation.
+  - id: eye_size
+    type: u1
+    doc: Eye size. Ranges from 0 to 7, small to large.
+  - id: eye_type
+    type: u1
+    doc: Eye type. Ranges from 0 to 59. Not ordered the same as visible in editor.
+  - id: eye_horizontal
+    type: u1
+    doc: Eye X (horizontal) distance. Ranges from 0 to 12, close to far.
+  - id: eye_vertical
+    type: u1
+    doc: Eye Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: eyebrow_stretch
+    type: u1
+    doc: Eyebrow stretch. Ranges from 0 to 6, small to large.
+  - id: eyebrow_color
+    type: u1
+    doc: Eyebrow color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: eyebrow_rotation
+    type: u1
+    doc: Eyebrow rotation. Ranges from 0 to 11, down to up. Note that some eyebrow types have a default rotation.
+  - id: eyebrow_size
+    type: u1
+    doc: Eyebrow size. Ranges from 0 to 8, small to large.
+  - id: eyebrow_type
+    type: u1
+    doc: Eyebrow type. Ranges from 0 to 23. Not ordered the same as visible in editor.
+  - id: eyebrow_horizontal
+    type: u1
+    doc: Eyebrow X (horizontal) distance. Ranges from 0 to 12, close to far.
+  - id: eyebrow_vertical
+    type: u1
+    doc: Eyebrow Y (vertical) distance. Ranges from 18 to 3, low to high.
+  - id: face_color
+    type: u1
+    doc: Skin color. Ranges from 0 to 9. Not ordered the same as visible in editor.
+  - id: face_makeup
+    type: u1
+    doc: Face makeup. Ranges from 0 to 11.
+  - id: face_type
+    type: u1
+    doc: Face shape. Ranges from 0 to 11. Not ordered the same as visible in editor.
+  - id: face_wrinkles
+    type: u1
+    doc: Face wrinkles. Ranges from 0 to 11.
+  - id: favorite_color
+    type: u1
+    doc: Favorite color. Ranges from 0 to 11.
+  - id: gender
+    type: u1
+    doc: Mii gender. 0 = male, 1 = female.
+  - id: glasses_color
+    type: u1
+    doc: Glasses color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: glasses_size
+    type: u1
+    doc: Glasses size. Ranges from 0 to 7, small to large.
+  - id: glasses_type
+    type: u1
+    doc: Glasses type. Ranges from 0 to 19. Not ordered the same as visible in editor.
+  - id: glasses_vertical
+    type: u1
+    doc: Glasses Y (vertical) position. Ranges from 20 to 0, low to high.
+  - id: hair_color
+    type: u1
+    doc: Hair color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: hair_flip
+    type: u1
+    doc: Flip hair. 0 = no, 1 = yes.
+  - id: hair_type
+    type: u1
+    doc: Hair type. Ranges from 0 to 131. Not ordered the same as visible in editor.
+  - id: body_height
+    type: u1
+    doc: Body height. Ranges from 0 to 127, short to tall.
+  - id: mole_size
+    type: u1
+    doc: Beauty mark size. Ranges from 0 to 8, small to large.
+  - id: mole_enable
+    type: u1
+    doc: Enable beauty mark. 0 = no, 1 = yes.
+  - id: mole_horizontal
+    type: u1
+    doc: Beauty mark X (horizontal) position. Ranges from 0 to 16, left to right.
+  - id: mole_vertical
+    type: u1
+    doc: Beauty mark Y (vertical) position. Ranges from 30 to 0, low to high.
+  - id: mouth_stretch
+    type: u1
+    doc: Mouth stretch. Ranges from 0 to 6, small to large.
+  - id: mouth_color
+    type: u1
+    doc: Mouth color. The default colors are ordered the same as visible in editor, ranging from 19 to 23. The custom colors are not and range from 0 to 99.
+  - id: mouth_size
+    type: u1
+    doc: Mouth size. Ranges from 0 to 8, small to large.
+  - id: mouth_type
+    type: u1
+    doc: Mouth type. Ranges from 0 to 35. Not ordered the same as visible in editor.
+  - id: mouth_vertical
+    type: u1
+    doc: Mouth Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: beard_size
+    type: u1
+    doc: Mustache size. Ranges from 0 to 8, small to large.
+  - id: beard_mustache
+    type: u1
+    doc: Mustache type. Ranges from 0 to 5.
+  - id: beard_vertical
+    type: u1
+    doc: Mustache Y (vertical) position. Ranges from 16 to 0, low to high.
+  - id: nose_size
+    type: u1
+    doc: Nose size. Ranges from 0 to 8, small to large.
+  - id: nose_type
+    type: u1
+    doc: Nose type. Ranges from 0 to 17. Not ordered the same as visible in editor.
+  - id: nose_vertical
+    type: u1
+    doc: Nose Y (vertical) position. Ranges from 18 to 0, low to high.

--- a/game/SwitchDB_Miidatafile.ksy
+++ b/game/SwitchDB_Miidatafile.ksy
@@ -1,0 +1,157 @@
+meta:
+  id: miidata_sdb
+  endian: le
+seq:
+  - id: hair_type
+    type: u1
+    doc: Hair type. Ranges from 0 to 131. Not ordered the same as visible in editor.
+  - id: mole_enable
+    type: b1
+    doc: Enable mole. 0 = no, 1 = yes.
+  - id: body_height
+    type: b7
+    doc: Body height. Ranges from 0 to 127, short to tall. In the Mii editor, pressing right will add 1 to this value, and pressing left will subtract 1, allowing for precise editing.
+  - id: hair_flip
+    type: b1
+    doc: Flip hair. 0 = no, 1 = yes.
+  - id: body_weight
+    type: b7
+    doc: Body weight. Ranges from 0 to 127, small to large. In the Mii editor, pressing right will add 1 to this value, and pressing left will subtract 1, allowing for precise editing.
+  - id: hair_color
+    type: u1
+    doc: Hair color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: gender
+    type: b1
+    doc: Mii gender. 0 = male, 1 = female.
+  - id: eye_color
+    type: b7
+    doc: Eye color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: eyebrow_color
+    type: u1
+    doc: Eyebrow color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: mouth_color
+    type: u1
+    doc: Mouth color. The default colors are ordered the same as visible in editor, ranging from 19 to 23. The custom colors are not and range from 0 to 99.
+  - id: facial_hair_color
+    type: u1
+    doc: Facial hair color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: glasses_color
+    type: u1
+    doc: Glasses color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: eye_type
+    type: u1
+    doc: Eye type. Ranges from 0 to 59. Not ordered the same as visible in editor.
+  - id: mouth_type
+    type: u1
+    doc: Mouth type. Ranges from 0 to 35. Not ordered the same as visible in editor.
+  - id: glasses_size
+    type: b3
+    doc: Glasses size. Ranges from 0 to 7, small to big.
+  - id: eye_vertical
+    type: b5
+    doc: Eye Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: facial_hair_mustache
+    type: b3
+    doc: Mustache type. Ranges from 0 to 5.
+  - id: eyebrow_type
+    type: b5
+    doc: Eyebrow type. Ranges from 0 to 23. Not ordered the same as visible in editor.
+  - id: facial_hair_beard
+    type: b3
+    doc: Beard type. Ranges from 0 to 5.
+  - id: nose_type
+    type: b5
+    doc: Nose type. Ranges from 0 to 17. Not ordered the same as visible in editor.
+  - id: mouth_stretch
+    type: b3
+    doc: Mouth stretch. Ranges from 0 to 6, small to big.
+  - id: nose_vertical
+    type: b5
+    doc: Nose Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: eyebrow_stretch
+    type: b3
+    doc: Eyebrow stretch. Ranges from 0 to 6, small to big.
+  - id: mouth_vertical
+    type: b5
+    doc: Mouth Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: eye_rotation
+    type: b3
+    doc: Eye rotation. Ranges from 0 to 7, down to up. Note that some eye types have a default rotation.
+  - id: facial_hair_vertical
+    type: b5
+    doc: Mustache Y (vertical) position. Ranges from 22 to 0, low to high.
+  - id: eye_stretch
+    type: b3
+    doc: Eye stretch. Ranges from 0 to 6, small to big.
+  - id: glasses_vertical
+    type: b5
+    doc: Glasses Y (vertical) position. Ranges from 20 to 0, low to high.
+  - id: eye_size
+    type: b3
+    doc: Eye size. Ranges from 0 to 7, small to big.
+  - id: mole_horizontal
+    type: b5
+    doc: Mole X (horizontal) position. Ranges from 0 to 16, left to right.
+  - id: mole_vertical
+    type: u1
+    doc: Mole Y (vertical) position. Ranges from 30 to 0, low to high.
+  - id: glasses_type
+    type: u1
+    doc: Glasses type. Ranges from 0 to 19. Not ordered the same as visible in editor.
+  - id: face_type
+    type: b4
+    doc: Face shape. Ranges from 0 to 11. Not ordered the same as visible in editor.
+  - id: favorite_color
+    type: b4
+    doc: Favorite color. Ranges from 0 to 11.
+  - id: face_wrinkles
+    type: b4
+    doc: Face wrinkles. Ranges from 0 to 11.
+  - id: face_color
+    type: b4
+    doc: Skin color. Ranges from 0 to 9. Not ordered the same as visible in editor.
+  - id: eye_horizontal
+    type: b4
+    doc: Eye X (horizontal) distance. Ranges from 0 to 12, close to far.
+  - id: face_makeup
+    type: b4
+    doc: Face makeup. Ranges from 0 to 11.
+  - id: eyebrow_rotation
+    type: b4
+    doc: Eyebrow rotation. Ranges from 0 to 11, down to up. Note that some eye types have a default rotation.
+  - id: eyebrow_size
+    type: b4
+    doc: Eyebrow size. Ranges from 0 to 8, small to big.
+  - id: eyebrow_vertical
+    type: b4
+    doc: Eyebrow Y (vertical) position. Ranges from 15 to 0, low to high.
+  - id: eyebrow_horizontal
+    type: b4
+    doc: Eyebrow X (horizontal) distance. Ranges from 0 to 12, close to far.
+  - id: mouth_size
+    type: b4
+    doc: Mouth size. Ranges from 0 to 8, small to big.
+  - id: nose_size
+    type: b4
+    doc: Nose size. Ranges from 0 to 8, small to big.
+  - id: mole_size
+    type: b4
+    doc: Mole size. Ranges from 0 to 8, small to big.
+  - id: facial_hair_size
+    type: b4
+    doc: Mustache size. Ranges from 0 to 8, small to big.
+  - id: mii_name
+    type: str
+    size: 20
+    encoding: utf-16le
+    doc: Mii name. Can be up to 10 characters long.
+  - id: unknown
+    type: u1
+    repeat: expr
+    repeat-expr: 16
+    doc: Currently unknown data.
+  - id: mii_id
+    type: u1
+    repeat: expr
+    repeat-expr: 4
+    doc: Mii ID. An identifier used to save Miis in most games.

--- a/game/Switch_Miidatafile.ksy
+++ b/game/Switch_Miidatafile.ksy
@@ -1,0 +1,167 @@
+meta:
+  id: miidata_swi
+  endian: le
+seq:
+  - id: unknown_data
+    type: u1
+    repeat: expr
+    repeat-expr: 16
+    doc: Currently unknown data.
+  - id: mii_name
+    type: str
+    size: 20
+    encoding: utf-16le
+    doc: Mii name. Can be up to 10 characters long. Different from the Mii name that appears in Super Smash Bros. Ultimate - in game, this is never seen.
+  - id: unknown_buffer
+    type: u1
+    repeat: expr
+    repeat-expr: 3
+    doc: Currently unknown data - likely a 00 buffer between the name and misc. info and the rest of the Mii data.
+  - id: favorite_color
+    type: u1
+    doc: Favorite color. Ranges from 0 to 11.
+  - id: gender
+    type: u1
+    doc: Mii gender. 0 = male, 1 = female.
+  - id: body_height
+    type: u1
+    doc: Body height. Ranges from 0 to 127, short to tall.
+  - id: body_weight
+    type: u1
+    doc: Body weight. Ranges from 0 to 127, small to large.
+  - id: unknown_buffer2
+    type: u1
+    repeat: expr
+    repeat-expr: 2
+    doc: Currently unknown data - likely a 00 buffer between the Mii body data and the Mii face data.
+  - id: face_type
+    type: u1
+    doc: Face shape. Ranges from 0 to 11. Not ordered the same as visible in editor.
+  - id: face_color
+    type: u1
+    doc: Skin color. Ranges from 0 to 9. Not ordered the same as visible in editor.
+  - id: face_wrinkles
+    type: u1
+    doc: Face wrinkles. Ranges from 0 to 11.
+  - id: face_makeup
+    type: u1
+    doc: Face makeup. Ranges from 0 to 11.
+  - id: hair_type
+    type: u1
+    doc: Hair type. Ranges from 0 to 131. Not ordered the same as visible in editor.
+  - id: hair_color
+    type: u1
+    doc: Hair color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: hair_flip
+    type: u1
+    doc: Flip hair. 0 = no, 1 = yes.
+  - id: eye_type
+    type: u1
+    doc: Eye type. Ranges from 0 to 59. Not ordered the same as visible in editor.
+  - id: eye_color
+    type: u1
+    doc: Eye color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: eye_size
+    type: u1
+    doc: Eye size. Ranges from 0 to 7, small to large.
+  - id: eye_stretch
+    type: u1
+    doc: Eye stretch. Ranges from 0 to 6, small to large.
+  - id: eye_rotation
+    type: u1
+    doc: Eye rotation. Ranges from 0 to 7, down to up. Note that some eye types have a default rotation.
+  - id: eye_horizontal
+    type: u1
+    doc: Eye X (horizontal) distance. Ranges from 0 to 12, close to far.
+  - id: eye_vertical
+    type: u1
+    doc: Eye Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: eyebrow_type
+    type: u1
+    doc: Eyebrow type. Ranges from 0 to 23. Not ordered the same as visible in editor.
+  - id: eyebrow_color
+    type: u1
+    doc: Eyebrow color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: eyebrow_size
+    type: u1
+    doc: Eyebrow size. Ranges from 0 to 8, small to large.
+  - id: eyebrow_stretch
+    type: u1
+    doc: Eyebrow stretch. Ranges from 0 to 6, small to large.
+  - id: eyebrow_rotation
+    type: u1
+    doc: Eyebrow rotation. Ranges from 0 to 11, down to up. Note that some eyebrow types have a default rotation.
+  - id: eyebrow_horizontal
+    type: u1
+    doc: Eyebrow X (horizontal) distance. Ranges from 0 to 12, close to far.
+  - id: eyebrow_vertical
+    type: u1
+    doc: Eyebrow Y (vertical) distance. Ranges from 18 to 3, low to high.
+  - id: nose_type
+    type: u1
+    doc: Nose type. Ranges from 0 to 17. Not ordered the same as visible in editor.
+  - id: nose_size
+    type: u1
+    doc: Nose size. Ranges from 0 to 8, small to large.
+  - id: nose_vertical
+    type: u1
+    doc: Nose Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: mouth_type
+    type: u1
+    doc: Mouth type. Ranges from 0 to 35. Not ordered the same as visible in editor.
+  - id: mouth_color
+    type: u1
+    doc: Mouth color. The default colors are ordered the same as visible in editor, ranging from 19 to 23. The custom colors are not and range from 0 to 99.
+  - id: mouth_size
+    type: u1
+    doc: Mouth size. Ranges from 0 to 8, small to large.
+  - id: mouth_stretch
+    type: u1
+    doc: Mouth stretch. Ranges from 0 to 6, small to large.
+  - id: mouth_vertical
+    type: u1
+    doc: Mouth Y (vertical) position. Ranges from 18 to 0, low to high.
+  - id: facial_hair_color
+    type: u1
+    doc: Facial hair color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: facial_hair_beard
+    type: u1
+    doc: Beard type. Ranges from 0 to 5.
+  - id: facial_hair_mustache
+    type: u1
+    doc: Mustache type. Ranges from 0 to 5.
+  - id: facial_hair_size
+    type: u1
+    doc: Mustache size. Ranges from 0 to 8, small to large.
+  - id: facial_hair_vertical
+    type: u1
+    doc: Mustache Y (vertical) position. Ranges from 16 to 0, low to high.
+  - id: glasses_type
+    type: u1
+    doc: Glasses type. Ranges from 0 to 19. Not ordered the same as visible in editor.
+  - id: glasses_color
+    type: u1
+    doc: Glasses color. Ranges from 0 to 99. Not ordered the same as visible in editor.
+  - id: glasses_size
+    type: u1
+    doc: Glasses size. Ranges from 0 to 7, small to large.
+  - id: glasses_vertical
+    type: u1
+    doc: Glasses Y (vertical) position. Ranges from 20 to 0, low to high.
+  - id: mole_enable
+    type: u1
+    doc: Enable mole. 0 = no, 1 = yes.
+  - id: mole_size
+    type: u1
+    doc: Mole size. Ranges from 0 to 8, small to large.
+  - id: mole_horizontal
+    type: u1
+    doc: Mole X (horizontal) position. Ranges from 0 to 16, left to right.
+  - id: mole_vertical
+    type: u1
+    doc: Mole Y (vertical) position. Ranges from 30 to 0, low to high.
+  - id: unknown_buffer3
+    type: u1
+    repeat: expr
+    repeat-expr: 1
+    doc: Currently unknown data - likely a 00 buffer.


### PR DESCRIPTION
added the Mii Studio Mii data file format: the Mii Studio (studio.mii.nintendo.com) stores Miis in this format. you can pull the Mii data from your browser's local storage, or by using this JavaScript code written by me and polished by bendevnul: https://github.com/RiiConnect24/mii2studio#importingexporting-to-mii-studio (instructions are on the page)

added the SwitchDB Mii data file format: the Nintendo Switch's internal Mii database uses a different format than used in games. this is the format of the Miis used in the internal database. highly compact, and can fit 10 characters of a Mii name (20 bytes). also includes some currently unknown data :( but it doesn't seem that this data is relevant, as even the Mii Studio format doesn't store it.

added the Switch Mii data file format: can store the exact same as the SwitchDB format, just this format is only used in games like Super Smash Bros. Ultimate and Mario Kart 8 Deluxe, while the SwitchDB is (as explained above) only used in the internal Mii database.

i documented and created the .ksy files for all of these formats. if needed, i can provide default and example files.